### PR TITLE
refactor: remove pointer arguments in module interface

### DIFF
--- a/core/module/mocks/loggable_module.go
+++ b/core/module/mocks/loggable_module.go
@@ -25,11 +25,11 @@ func (_m *LoggableModule) EXPECT() *LoggableModule_Expecter {
 }
 
 // Act provides a mock function with given fields: r, action, params
-func (_m *LoggableModule) Act(r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (_m *LoggableModule) Act(r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	ret := _m.Called(r, action, params)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(*resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
 		r0 = rf(r, action, params)
 	} else {
 		if ret.Get(0) != nil {
@@ -38,7 +38,7 @@ func (_m *LoggableModule) Act(r *resource.Resource, action string, params map[st
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*resource.Resource, string, map[string]interface{}) error); ok {
+	if rf, ok := ret.Get(1).(func(resource.Resource, string, map[string]interface{}) error); ok {
 		r1 = rf(r, action, params)
 	} else {
 		r1 = ret.Error(1)
@@ -53,16 +53,16 @@ type LoggableModule_Act_Call struct {
 }
 
 // Act is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 //  - action string
 //  - params map[string]interface{}
 func (_e *LoggableModule_Expecter) Act(r interface{}, action interface{}, params interface{}) *LoggableModule_Act_Call {
 	return &LoggableModule_Act_Call{Call: _e.mock.On("Act", r, action, params)}
 }
 
-func (_c *LoggableModule_Act_Call) Run(run func(r *resource.Resource, action string, params map[string]interface{})) *LoggableModule_Act_Call {
+func (_c *LoggableModule_Act_Call) Run(run func(r resource.Resource, action string, params map[string]interface{})) *LoggableModule_Act_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource), args[1].(string), args[2].(map[string]interface{}))
+		run(args[0].(resource.Resource), args[1].(string), args[2].(map[string]interface{}))
 	})
 	return _c
 }
@@ -73,18 +73,18 @@ func (_c *LoggableModule_Act_Call) Return(_a0 map[string]interface{}, _a1 error)
 }
 
 // Apply provides a mock function with given fields: r
-func (_m *LoggableModule) Apply(r *resource.Resource) (resource.Status, error) {
+func (_m *LoggableModule) Apply(r resource.Resource) (resource.Status, error) {
 	ret := _m.Called(r)
 
 	var r0 resource.Status
-	if rf, ok := ret.Get(0).(func(*resource.Resource) resource.Status); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) resource.Status); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Get(0).(resource.Status)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(1).(func(resource.Resource) error); ok {
 		r1 = rf(r)
 	} else {
 		r1 = ret.Error(1)
@@ -99,14 +99,14 @@ type LoggableModule_Apply_Call struct {
 }
 
 // Apply is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *LoggableModule_Expecter) Apply(r interface{}) *LoggableModule_Apply_Call {
 	return &LoggableModule_Apply_Call{Call: _e.mock.On("Apply", r)}
 }
 
-func (_c *LoggableModule_Apply_Call) Run(run func(r *resource.Resource)) *LoggableModule_Apply_Call {
+func (_c *LoggableModule_Apply_Call) Run(run func(r resource.Resource)) *LoggableModule_Apply_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }
@@ -153,11 +153,11 @@ func (_c *LoggableModule_ID_Call) Return(_a0 string) *LoggableModule_ID_Call {
 }
 
 // Log provides a mock function with given fields: ctx, r, filter
-func (_m *LoggableModule) Log(ctx context.Context, r *resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
+func (_m *LoggableModule) Log(ctx context.Context, r resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
 	ret := _m.Called(ctx, r, filter)
 
 	var r0 <-chan module.LogChunk
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource, map[string]string) <-chan module.LogChunk); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource, map[string]string) <-chan module.LogChunk); ok {
 		r0 = rf(ctx, r, filter)
 	} else {
 		if ret.Get(0) != nil {
@@ -166,7 +166,7 @@ func (_m *LoggableModule) Log(ctx context.Context, r *resource.Resource, filter 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource, map[string]string) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource, map[string]string) error); ok {
 		r1 = rf(ctx, r, filter)
 	} else {
 		r1 = ret.Error(1)
@@ -182,15 +182,15 @@ type LoggableModule_Log_Call struct {
 
 // Log is a helper method to define mock.On call
 //  - ctx context.Context
-//  - r *resource.Resource
+//  - r resource.Resource
 //  - filter map[string]string
 func (_e *LoggableModule_Expecter) Log(ctx interface{}, r interface{}, filter interface{}) *LoggableModule_Log_Call {
 	return &LoggableModule_Log_Call{Call: _e.mock.On("Log", ctx, r, filter)}
 }
 
-func (_c *LoggableModule_Log_Call) Run(run func(ctx context.Context, r *resource.Resource, filter map[string]string)) *LoggableModule_Log_Call {
+func (_c *LoggableModule_Log_Call) Run(run func(ctx context.Context, r resource.Resource, filter map[string]string)) *LoggableModule_Log_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource), args[2].(map[string]string))
+		run(args[0].(context.Context), args[1].(resource.Resource), args[2].(map[string]string))
 	})
 	return _c
 }
@@ -201,11 +201,11 @@ func (_c *LoggableModule_Log_Call) Return(_a0 <-chan module.LogChunk, _a1 error)
 }
 
 // Validate provides a mock function with given fields: r
-func (_m *LoggableModule) Validate(r *resource.Resource) error {
+func (_m *LoggableModule) Validate(r resource.Resource) error {
 	ret := _m.Called(r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) error); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Error(0)
@@ -220,14 +220,14 @@ type LoggableModule_Validate_Call struct {
 }
 
 // Validate is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *LoggableModule_Expecter) Validate(r interface{}) *LoggableModule_Validate_Call {
 	return &LoggableModule_Validate_Call{Call: _e.mock.On("Validate", r)}
 }
 
-func (_c *LoggableModule_Validate_Call) Run(run func(r *resource.Resource)) *LoggableModule_Validate_Call {
+func (_c *LoggableModule_Validate_Call) Run(run func(r resource.Resource)) *LoggableModule_Validate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }

--- a/core/module/mocks/module.go
+++ b/core/module/mocks/module.go
@@ -22,11 +22,11 @@ func (_m *Module) EXPECT() *Module_Expecter {
 }
 
 // Act provides a mock function with given fields: r, action, params
-func (_m *Module) Act(r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (_m *Module) Act(r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	ret := _m.Called(r, action, params)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(*resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
 		r0 = rf(r, action, params)
 	} else {
 		if ret.Get(0) != nil {
@@ -35,7 +35,7 @@ func (_m *Module) Act(r *resource.Resource, action string, params map[string]int
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*resource.Resource, string, map[string]interface{}) error); ok {
+	if rf, ok := ret.Get(1).(func(resource.Resource, string, map[string]interface{}) error); ok {
 		r1 = rf(r, action, params)
 	} else {
 		r1 = ret.Error(1)
@@ -50,16 +50,16 @@ type Module_Act_Call struct {
 }
 
 // Act is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 //  - action string
 //  - params map[string]interface{}
 func (_e *Module_Expecter) Act(r interface{}, action interface{}, params interface{}) *Module_Act_Call {
 	return &Module_Act_Call{Call: _e.mock.On("Act", r, action, params)}
 }
 
-func (_c *Module_Act_Call) Run(run func(r *resource.Resource, action string, params map[string]interface{})) *Module_Act_Call {
+func (_c *Module_Act_Call) Run(run func(r resource.Resource, action string, params map[string]interface{})) *Module_Act_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource), args[1].(string), args[2].(map[string]interface{}))
+		run(args[0].(resource.Resource), args[1].(string), args[2].(map[string]interface{}))
 	})
 	return _c
 }
@@ -70,18 +70,18 @@ func (_c *Module_Act_Call) Return(_a0 map[string]interface{}, _a1 error) *Module
 }
 
 // Apply provides a mock function with given fields: r
-func (_m *Module) Apply(r *resource.Resource) (resource.Status, error) {
+func (_m *Module) Apply(r resource.Resource) (resource.Status, error) {
 	ret := _m.Called(r)
 
 	var r0 resource.Status
-	if rf, ok := ret.Get(0).(func(*resource.Resource) resource.Status); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) resource.Status); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Get(0).(resource.Status)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(1).(func(resource.Resource) error); ok {
 		r1 = rf(r)
 	} else {
 		r1 = ret.Error(1)
@@ -96,14 +96,14 @@ type Module_Apply_Call struct {
 }
 
 // Apply is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *Module_Expecter) Apply(r interface{}) *Module_Apply_Call {
 	return &Module_Apply_Call{Call: _e.mock.On("Apply", r)}
 }
 
-func (_c *Module_Apply_Call) Run(run func(r *resource.Resource)) *Module_Apply_Call {
+func (_c *Module_Apply_Call) Run(run func(r resource.Resource)) *Module_Apply_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }
@@ -150,11 +150,11 @@ func (_c *Module_ID_Call) Return(_a0 string) *Module_ID_Call {
 }
 
 // Validate provides a mock function with given fields: r
-func (_m *Module) Validate(r *resource.Resource) error {
+func (_m *Module) Validate(r resource.Resource) error {
 	ret := _m.Called(r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) error); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Error(0)
@@ -169,14 +169,14 @@ type Module_Validate_Call struct {
 }
 
 // Validate is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *Module_Expecter) Validate(r interface{}) *Module_Validate_Call {
 	return &Module_Validate_Call{Call: _e.mock.On("Validate", r)}
 }
 
-func (_c *Module_Validate_Call) Run(run func(r *resource.Resource)) *Module_Validate_Call {
+func (_c *Module_Validate_Call) Run(run func(r resource.Resource)) *Module_Validate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -21,15 +21,15 @@ var (
 
 type Module interface {
 	ID() string
-	Act(r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error)
-	Apply(r *resource.Resource) (resource.Status, error)
-	Validate(r *resource.Resource) error
+	Act(r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error)
+	Apply(r resource.Resource) (resource.Status, error)
+	Validate(r resource.Resource) error
 }
 
 type Loggable interface {
 	Module
 
-	Log(ctx context.Context, r *resource.Resource, filter map[string]string) (<-chan LogChunk, error)
+	Log(ctx context.Context, r resource.Resource, filter map[string]string) (<-chan LogChunk, error)
 }
 
 type LogChunk struct {

--- a/core/module/service.go
+++ b/core/module/service.go
@@ -16,18 +16,18 @@ func NewService(moduleRepository Repository) *Service {
 	}
 }
 
-func (s *Service) Sync(ctx context.Context, r *resource.Resource) (*resource.Resource, error) {
+func (s *Service) Sync(ctx context.Context, r resource.Resource) (*resource.Resource, error) {
 	module, err := s.moduleRepository.Get(r.Kind)
 	if err != nil {
 		r.Status = resource.StatusError
-		return r, err
+		return &r, err
 	}
 	status, err := module.Apply(r)
 	r.Status = status
-	return r, err
+	return &r, err
 }
 
-func (s *Service) Validate(ctx context.Context, r *resource.Resource) error {
+func (s *Service) Validate(ctx context.Context, r resource.Resource) error {
 	module, err := s.moduleRepository.Get(r.Kind)
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func (s *Service) Validate(ctx context.Context, r *resource.Resource) error {
 	return err
 }
 
-func (s *Service) Act(ctx context.Context, r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (s *Service) Act(ctx context.Context, r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	module, err := s.moduleRepository.Get(r.Kind)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (s *Service) Act(ctx context.Context, r *resource.Resource, action string, 
 	return output, nil
 }
 
-func (s *Service) Log(ctx context.Context, r *resource.Resource, filter map[string]string) (<-chan LogChunk, error) {
+func (s *Service) Log(ctx context.Context, r resource.Resource, filter map[string]string) (<-chan LogChunk, error) {
 	module, err := s.moduleRepository.Get(r.Kind)
 	if err != nil {
 		return nil, err

--- a/core/module/service_test.go
+++ b/core/module/service_test.go
@@ -16,15 +16,12 @@ import (
 )
 
 func TestService_Sync(t *testing.T) {
-	type fields struct {
-		moduleRepository module.Repository
-	}
-	type args struct {
-		ctx context.Context
-		r   *resource.Resource
-	}
-	currentTime := time.Now()
-	r := &resource.Resource{
+	t.Parallel()
+
+	frozenTime := time.Now()
+	sampleApplyErr := errors.New("apply failed")
+
+	sampleResource := resource.Resource{
 		URN:       "p-testdata-gl-testname-mock",
 		Name:      "testname",
 		Parent:    "p-testdata-gl",
@@ -32,36 +29,30 @@ func TestService_Sync(t *testing.T) {
 		Configs:   map[string]interface{}{},
 		Labels:    map[string]string{},
 		Status:    resource.StatusPending,
-		CreatedAt: currentTime,
-		UpdatedAt: currentTime,
+		CreatedAt: frozenTime,
+		UpdatedAt: frozenTime,
 	}
-	applyFailedErr := errors.New("apply failed")
-
-	mockModule := &mocks.Module{}
-	mockModule.EXPECT().ID().Return("mock")
-	mockModuleRepo := &mocks.ModuleRepository{}
 
 	tests := []struct {
 		name    string
-		setup   func(t *testing.T)
-		fields  fields
-		args    args
+		setup   func(t *testing.T) *module.Service
+		r       resource.Resource
 		want    *resource.Resource
 		wantErr error
 	}{
 		{
-			name: "test sync completed",
-			setup: func(t *testing.T) {
-				mockModule.EXPECT().Apply(r).Return(resource.StatusCompleted, nil).Once()
+			name: "Success",
+			setup: func(t *testing.T) *module.Service {
+				mockModule := &mocks.Module{}
+				mockModule.EXPECT().ID().Return("mock")
+				mockModule.EXPECT().Apply(sampleResource).Return(resource.StatusCompleted, nil).Once()
+
+				mockModuleRepo := &mocks.ModuleRepository{}
 				mockModuleRepo.EXPECT().Get("mock").Return(mockModule, nil).Once()
+
+				return module.NewService(mockModuleRepo)
 			},
-			fields: fields{
-				moduleRepository: mockModuleRepo,
-			},
-			args: args{
-				ctx: nil,
-				r:   r,
-			},
+			r: sampleResource,
 			want: &resource.Resource{
 				URN:       "p-testdata-gl-testname-mock",
 				Name:      "testname",
@@ -70,23 +61,19 @@ func TestService_Sync(t *testing.T) {
 				Configs:   map[string]interface{}{},
 				Labels:    map[string]string{},
 				Status:    resource.StatusCompleted,
-				CreatedAt: currentTime,
-				UpdatedAt: currentTime,
+				CreatedAt: frozenTime,
+				UpdatedAt: frozenTime,
 			},
 			wantErr: nil,
 		},
 		{
-			name: "test sync module not found error",
-			setup: func(t *testing.T) {
+			name: "ModuleNotFound",
+			setup: func(t *testing.T) *module.Service {
+				mockModuleRepo := &mocks.ModuleRepository{}
 				mockModuleRepo.EXPECT().Get("mock").Return(nil, module.ErrModuleNotFound).Once()
+				return module.NewService(mockModuleRepo)
 			},
-			fields: fields{
-				moduleRepository: mockModuleRepo,
-			},
-			args: args{
-				ctx: nil,
-				r:   r,
-			},
+			r: sampleResource,
 			want: &resource.Resource{
 				URN:       "p-testdata-gl-testname-mock",
 				Name:      "testname",
@@ -95,25 +82,24 @@ func TestService_Sync(t *testing.T) {
 				Configs:   map[string]interface{}{},
 				Labels:    map[string]string{},
 				Status:    resource.StatusError,
-				CreatedAt: currentTime,
-				UpdatedAt: currentTime,
+				CreatedAt: frozenTime,
+				UpdatedAt: frozenTime,
 			},
 			wantErr: module.ErrModuleNotFound,
 		},
 		{
-			name: "test sync module error while applying",
-			setup: func(t *testing.T) {
-				mockModule.EXPECT().Apply(r).Return(resource.StatusError, applyFailedErr).Once()
+			name: "ApplyFailure",
+			setup: func(t *testing.T) *module.Service {
+				mockModule := &mocks.Module{}
+				mockModule.EXPECT().ID().Return("mock")
+				mockModule.EXPECT().Apply(sampleResource).Return(resource.StatusError, sampleApplyErr).Once()
 
+				mockModuleRepo := &mocks.ModuleRepository{}
 				mockModuleRepo.EXPECT().Get("mock").Return(mockModule, nil).Once()
+
+				return module.NewService(mockModuleRepo)
 			},
-			fields: fields{
-				moduleRepository: mockModuleRepo,
-			},
-			args: args{
-				ctx: nil,
-				r:   r,
-			},
+			r: sampleResource,
 			want: &resource.Resource{
 				URN:       "p-testdata-gl-testname-mock",
 				Name:      "testname",
@@ -122,25 +108,24 @@ func TestService_Sync(t *testing.T) {
 				Configs:   map[string]interface{}{},
 				Labels:    map[string]string{},
 				Status:    resource.StatusError,
-				CreatedAt: currentTime,
-				UpdatedAt: currentTime,
+				CreatedAt: frozenTime,
+				UpdatedAt: frozenTime,
 			},
-			wantErr: applyFailedErr,
+			wantErr: sampleApplyErr,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := module.NewService(tt.fields.moduleRepository)
-			tt.setup(t)
+			moduleSvc := tt.setup(t)
 
-			got, err := s.Sync(tt.args.ctx, tt.args.r)
-			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("Sync() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			got, err := moduleSvc.Sync(context.Background(), tt.r)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tt.wantErr))
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Sync() got = %v, want %v", got, tt.want)
-			}
+
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -228,7 +213,7 @@ func TestService_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := module.NewService(tt.fields.moduleRepository)
 			tt.setup(t)
-			if err := s.Validate(tt.args.ctx, tt.args.r); !errors.Is(err, tt.wantErr) {
+			if err := s.Validate(tt.args.ctx, *tt.args.r); !errors.Is(err, tt.wantErr) {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -297,7 +282,7 @@ func TestService_Act(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := module.NewService(tt.fields.moduleRepository)
 			tt.setup(t)
-			got, err := s.Act(tt.args.ctx, tt.args.r, tt.args.action, tt.args.params)
+			got, err := s.Act(tt.args.ctx, *tt.args.r, tt.args.action, tt.args.params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Act() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -400,7 +385,7 @@ func TestService_Log(t *testing.T) {
 			tt.setup(t)
 			s := module.NewService(tt.fields.moduleRepository)
 
-			got, err := s.Log(tt.args.ctx, tt.args.r, tt.args.filter)
+			got, err := s.Log(tt.args.ctx, *tt.args.r, tt.args.filter)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Log() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/core/provider/mocks/provider_repository.go
+++ b/core/provider/mocks/provider_repository.go
@@ -21,11 +21,11 @@ func (_m *ProviderRepository) EXPECT() *ProviderRepository_Expecter {
 }
 
 // Create provides a mock function with given fields: r
-func (_m *ProviderRepository) Create(r *provider.Provider) error {
+func (_m *ProviderRepository) Create(r provider.Provider) error {
 	ret := _m.Called(r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*provider.Provider) error); ok {
+	if rf, ok := ret.Get(0).(func(provider.Provider) error); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Error(0)
@@ -40,14 +40,14 @@ type ProviderRepository_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//  - r *provider.Provider
+//  - r provider.Provider
 func (_e *ProviderRepository_Expecter) Create(r interface{}) *ProviderRepository_Create_Call {
 	return &ProviderRepository_Create_Call{Call: _e.mock.On("Create", r)}
 }
 
-func (_c *ProviderRepository_Create_Call) Run(run func(r *provider.Provider)) *ProviderRepository_Create_Call {
+func (_c *ProviderRepository_Create_Call) Run(run func(r provider.Provider)) *ProviderRepository_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*provider.Provider))
+		run(args[0].(provider.Provider))
 	})
 	return _c
 }

--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -18,7 +18,7 @@ type Repository interface {
 
 	GetByURN(urn string) (*Provider, error)
 	List(filter map[string]string) ([]*Provider, error)
-	Create(r *Provider) error
+	Create(r Provider) error
 }
 
 type Provider struct {

--- a/core/provider/service.go
+++ b/core/provider/service.go
@@ -12,7 +12,7 @@ func NewService(repository Repository) *Service {
 	}
 }
 
-func (s *Service) CreateProvider(ctx context.Context, pro *Provider) (*Provider, error) {
+func (s *Service) CreateProvider(ctx context.Context, pro Provider) (*Provider, error) {
 	err := s.repo.Create(pro)
 	if err != nil {
 		return nil, err

--- a/core/provider/service_test.go
+++ b/core/provider/service_test.go
@@ -28,7 +28,7 @@ func TestService_CreateProvider(t *testing.T) {
 				repo := &mocks.ProviderRepository{}
 				repo.EXPECT().
 					Create(mock.Anything).
-					Run(func(p *provider.Provider) {
+					Run(func(p provider.Provider) {
 						assert.Equal(t, p.URN, "foo")
 					}).
 					Return(errors.New("failed")).
@@ -45,7 +45,7 @@ func TestService_CreateProvider(t *testing.T) {
 				repo := &mocks.ProviderRepository{}
 				repo.EXPECT().
 					Create(mock.Anything).
-					Run(func(p *provider.Provider) {
+					Run(func(p provider.Provider) {
 						assert.Equal(t, p.URN, "foo")
 					}).
 					Return(nil).
@@ -72,9 +72,9 @@ func TestService_CreateProvider(t *testing.T) {
 				repo := &mocks.ProviderRepository{}
 				repo.EXPECT().
 					Create(mock.Anything).
-					Run(func(p *provider.Provider) {
+					Run(func(p provider.Provider) {
 						assert.Equal(t, p.URN, "foo")
-						storedProvider = *p
+						storedProvider = p
 					}).
 					Return(nil).
 					Once()
@@ -99,7 +99,7 @@ func TestService_CreateProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := provider.NewService(tt.setupRepo(t))
 
-			got, err := s.CreateProvider(context.Background(), &tt.provider)
+			got, err := s.CreateProvider(context.Background(), tt.provider)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/core/resource/mocks/resource_repository.go
+++ b/core/resource/mocks/resource_repository.go
@@ -21,11 +21,11 @@ func (_m *ResourceRepository) EXPECT() *ResourceRepository_Expecter {
 }
 
 // Create provides a mock function with given fields: r
-func (_m *ResourceRepository) Create(r *resource.Resource) error {
+func (_m *ResourceRepository) Create(r resource.Resource) error {
 	ret := _m.Called(r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) error); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Error(0)
@@ -40,14 +40,14 @@ type ResourceRepository_Create_Call struct {
 }
 
 // Create is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *ResourceRepository_Expecter) Create(r interface{}) *ResourceRepository_Create_Call {
 	return &ResourceRepository_Create_Call{Call: _e.mock.On("Create", r)}
 }
 
-func (_c *ResourceRepository_Create_Call) Run(run func(r *resource.Resource)) *ResourceRepository_Create_Call {
+func (_c *ResourceRepository_Create_Call) Run(run func(r resource.Resource)) *ResourceRepository_Create_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }
@@ -223,11 +223,11 @@ func (_c *ResourceRepository_Migrate_Call) Return(_a0 error) *ResourceRepository
 }
 
 // Update provides a mock function with given fields: r
-func (_m *ResourceRepository) Update(r *resource.Resource) error {
+func (_m *ResourceRepository) Update(r resource.Resource) error {
 	ret := _m.Called(r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*resource.Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(resource.Resource) error); ok {
 		r0 = rf(r)
 	} else {
 		r0 = ret.Error(0)
@@ -242,14 +242,14 @@ type ResourceRepository_Update_Call struct {
 }
 
 // Update is a helper method to define mock.On call
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *ResourceRepository_Expecter) Update(r interface{}) *ResourceRepository_Update_Call {
 	return &ResourceRepository_Update_Call{Call: _e.mock.On("Update", r)}
 }
 
-func (_c *ResourceRepository_Update_Call) Run(run func(r *resource.Resource)) *ResourceRepository_Update_Call {
+func (_c *ResourceRepository_Update_Call) Run(run func(r resource.Resource)) *ResourceRepository_Update_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*resource.Resource))
+		run(args[0].(resource.Resource))
 	})
 	return _c
 }

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -27,8 +27,8 @@ type Repository interface {
 
 	GetByURN(urn string) (*Resource, error)
 	List(filter map[string]string) ([]*Resource, error)
-	Create(r *Resource) error
-	Update(r *Resource) error
+	Create(r Resource) error
+	Update(r Resource) error
 	Delete(urn string) error
 }
 

--- a/core/resource/service.go
+++ b/core/resource/service.go
@@ -27,7 +27,7 @@ func (s *Service) ListResources(ctx context.Context, parent string, kind string)
 	return s.resourceRepository.List(filter)
 }
 
-func (s *Service) CreateResource(ctx context.Context, res *Resource) (*Resource, error) {
+func (s *Service) CreateResource(ctx context.Context, res Resource) (*Resource, error) {
 	res.Status = StatusPending
 
 	err := s.resourceRepository.Create(res)
@@ -42,7 +42,7 @@ func (s *Service) CreateResource(ctx context.Context, res *Resource) (*Resource,
 	return createdResource, nil
 }
 
-func (s *Service) UpdateResource(ctx context.Context, res *Resource) (*Resource, error) {
+func (s *Service) UpdateResource(ctx context.Context, res Resource) (*Resource, error) {
 	err := s.resourceRepository.Update(res)
 	if err != nil {
 		return nil, err

--- a/core/resource/service_test.go
+++ b/core/resource/service_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestService_CreateResource(t *testing.T) {
 	t.Run("test create new resource", func(t *testing.T) {
-		argResource := &resource.Resource{
+		argResource := resource.Resource{
 			URN:     "p-testdata-gl-testname-log",
 			Name:    "testname",
 			Parent:  "p-testdata-gl",
@@ -39,7 +39,7 @@ func TestService_CreateResource(t *testing.T) {
 		wantErr := error(nil)
 
 		mockRepo := &mocks.ResourceRepository{}
-		mockRepo.EXPECT().Create(mock.Anything).Run(func(r *resource.Resource) {
+		mockRepo.EXPECT().Create(mock.Anything).Run(func(r resource.Resource) {
 			assert.Equal(t, resource.StatusPending, r.Status)
 		}).Return(nil).Once()
 
@@ -68,7 +68,7 @@ func TestService_CreateResource(t *testing.T) {
 
 	t.Run("test create duplicate resource", func(t *testing.T) {
 		mockRepo := &mocks.ResourceRepository{}
-		argResource := &resource.Resource{
+		argResource := resource.Resource{
 			URN:     "p-testdata-gl-testname-log",
 			Name:    "testname",
 			Parent:  "p-testdata-gl",
@@ -78,7 +78,7 @@ func TestService_CreateResource(t *testing.T) {
 		}
 		want := (*resource.Resource)(nil)
 		wantErr := resource.ErrResourceAlreadyExists
-		mockRepo.EXPECT().Create(mock.Anything).Run(func(r *resource.Resource) {
+		mockRepo.EXPECT().Create(mock.Anything).Run(func(r resource.Resource) {
 			assert.Equal(t, resource.StatusPending, r.Status)
 		}).Return(resource.ErrResourceAlreadyExists).Once()
 
@@ -114,7 +114,7 @@ func TestService_UpdateResource(t *testing.T) {
 		}
 		wantErr := error(nil)
 
-		mockRepo.EXPECT().Update(mock.Anything).Run(func(r *resource.Resource) {
+		mockRepo.EXPECT().Update(mock.Anything).Run(func(r resource.Resource) {
 			assert.Equal(t, "p-testdata-gl-testname-log", r.URN)
 			assert.Equal(t, resource.StatusPending, r.Status)
 			assert.Equal(t, currentTime, r.CreatedAt)
@@ -135,7 +135,7 @@ func TestService_UpdateResource(t *testing.T) {
 		}, nil).Once()
 
 		s := resource.NewService(mockRepo)
-		got, err := s.UpdateResource(context.Background(), &resource.Resource{
+		got, err := s.UpdateResource(context.Background(), resource.Resource{
 			URN:       "p-testdata-gl-testname-log",
 			Name:      "testname",
 			Parent:    "p-testdata-gl",
@@ -167,7 +167,7 @@ func TestService_UpdateResource(t *testing.T) {
 			Once()
 
 		s := resource.NewService(mockRepo)
-		got, err := s.UpdateResource(context.Background(), &resource.Resource{
+		got, err := s.UpdateResource(context.Background(), resource.Resource{
 			URN:       "p-testdata-gl-testname-log",
 			Name:      "testname",
 			Parent:    "p-testdata-gl",

--- a/internal/server/v1/mocks/module_service.go
+++ b/internal/server/v1/mocks/module_service.go
@@ -26,11 +26,11 @@ func (_m *ModuleService) EXPECT() *ModuleService_Expecter {
 }
 
 // Act provides a mock function with given fields: ctx, r, action, params
-func (_m *ModuleService) Act(ctx context.Context, r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (_m *ModuleService) Act(ctx context.Context, r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	ret := _m.Called(ctx, r, action, params)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource, string, map[string]interface{}) map[string]interface{}); ok {
 		r0 = rf(ctx, r, action, params)
 	} else {
 		if ret.Get(0) != nil {
@@ -39,7 +39,7 @@ func (_m *ModuleService) Act(ctx context.Context, r *resource.Resource, action s
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource, string, map[string]interface{}) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource, string, map[string]interface{}) error); ok {
 		r1 = rf(ctx, r, action, params)
 	} else {
 		r1 = ret.Error(1)
@@ -55,16 +55,16 @@ type ModuleService_Act_Call struct {
 
 // Act is a helper method to define mock.On call
 //  - ctx context.Context
-//  - r *resource.Resource
+//  - r resource.Resource
 //  - action string
 //  - params map[string]interface{}
 func (_e *ModuleService_Expecter) Act(ctx interface{}, r interface{}, action interface{}, params interface{}) *ModuleService_Act_Call {
 	return &ModuleService_Act_Call{Call: _e.mock.On("Act", ctx, r, action, params)}
 }
 
-func (_c *ModuleService_Act_Call) Run(run func(ctx context.Context, r *resource.Resource, action string, params map[string]interface{})) *ModuleService_Act_Call {
+func (_c *ModuleService_Act_Call) Run(run func(ctx context.Context, r resource.Resource, action string, params map[string]interface{})) *ModuleService_Act_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource), args[2].(string), args[3].(map[string]interface{}))
+		run(args[0].(context.Context), args[1].(resource.Resource), args[2].(string), args[3].(map[string]interface{}))
 	})
 	return _c
 }
@@ -75,11 +75,11 @@ func (_c *ModuleService_Act_Call) Return(_a0 map[string]interface{}, _a1 error) 
 }
 
 // Log provides a mock function with given fields: ctx, r, filter
-func (_m *ModuleService) Log(ctx context.Context, r *resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
+func (_m *ModuleService) Log(ctx context.Context, r resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
 	ret := _m.Called(ctx, r, filter)
 
 	var r0 <-chan module.LogChunk
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource, map[string]string) <-chan module.LogChunk); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource, map[string]string) <-chan module.LogChunk); ok {
 		r0 = rf(ctx, r, filter)
 	} else {
 		if ret.Get(0) != nil {
@@ -88,7 +88,7 @@ func (_m *ModuleService) Log(ctx context.Context, r *resource.Resource, filter m
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource, map[string]string) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource, map[string]string) error); ok {
 		r1 = rf(ctx, r, filter)
 	} else {
 		r1 = ret.Error(1)
@@ -104,15 +104,15 @@ type ModuleService_Log_Call struct {
 
 // Log is a helper method to define mock.On call
 //  - ctx context.Context
-//  - r *resource.Resource
+//  - r resource.Resource
 //  - filter map[string]string
 func (_e *ModuleService_Expecter) Log(ctx interface{}, r interface{}, filter interface{}) *ModuleService_Log_Call {
 	return &ModuleService_Log_Call{Call: _e.mock.On("Log", ctx, r, filter)}
 }
 
-func (_c *ModuleService_Log_Call) Run(run func(ctx context.Context, r *resource.Resource, filter map[string]string)) *ModuleService_Log_Call {
+func (_c *ModuleService_Log_Call) Run(run func(ctx context.Context, r resource.Resource, filter map[string]string)) *ModuleService_Log_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource), args[2].(map[string]string))
+		run(args[0].(context.Context), args[1].(resource.Resource), args[2].(map[string]string))
 	})
 	return _c
 }
@@ -123,11 +123,11 @@ func (_c *ModuleService_Log_Call) Return(_a0 <-chan module.LogChunk, _a1 error) 
 }
 
 // Sync provides a mock function with given fields: ctx, r
-func (_m *ModuleService) Sync(ctx context.Context, r *resource.Resource) (*resource.Resource, error) {
+func (_m *ModuleService) Sync(ctx context.Context, r resource.Resource) (*resource.Resource, error) {
 	ret := _m.Called(ctx, r)
 
 	var r0 *resource.Resource
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource) *resource.Resource); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource) *resource.Resource); ok {
 		r0 = rf(ctx, r)
 	} else {
 		if ret.Get(0) != nil {
@@ -136,7 +136,7 @@ func (_m *ModuleService) Sync(ctx context.Context, r *resource.Resource) (*resou
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource) error); ok {
 		r1 = rf(ctx, r)
 	} else {
 		r1 = ret.Error(1)
@@ -152,14 +152,14 @@ type ModuleService_Sync_Call struct {
 
 // Sync is a helper method to define mock.On call
 //  - ctx context.Context
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *ModuleService_Expecter) Sync(ctx interface{}, r interface{}) *ModuleService_Sync_Call {
 	return &ModuleService_Sync_Call{Call: _e.mock.On("Sync", ctx, r)}
 }
 
-func (_c *ModuleService_Sync_Call) Run(run func(ctx context.Context, r *resource.Resource)) *ModuleService_Sync_Call {
+func (_c *ModuleService_Sync_Call) Run(run func(ctx context.Context, r resource.Resource)) *ModuleService_Sync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource))
+		run(args[0].(context.Context), args[1].(resource.Resource))
 	})
 	return _c
 }
@@ -170,11 +170,11 @@ func (_c *ModuleService_Sync_Call) Return(_a0 *resource.Resource, _a1 error) *Mo
 }
 
 // Validate provides a mock function with given fields: ctx, r
-func (_m *ModuleService) Validate(ctx context.Context, r *resource.Resource) error {
+func (_m *ModuleService) Validate(ctx context.Context, r resource.Resource) error {
 	ret := _m.Called(ctx, r)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource) error); ok {
 		r0 = rf(ctx, r)
 	} else {
 		r0 = ret.Error(0)
@@ -190,14 +190,14 @@ type ModuleService_Validate_Call struct {
 
 // Validate is a helper method to define mock.On call
 //  - ctx context.Context
-//  - r *resource.Resource
+//  - r resource.Resource
 func (_e *ModuleService_Expecter) Validate(ctx interface{}, r interface{}) *ModuleService_Validate_Call {
 	return &ModuleService_Validate_Call{Call: _e.mock.On("Validate", ctx, r)}
 }
 
-func (_c *ModuleService_Validate_Call) Run(run func(ctx context.Context, r *resource.Resource)) *ModuleService_Validate_Call {
+func (_c *ModuleService_Validate_Call) Run(run func(ctx context.Context, r resource.Resource)) *ModuleService_Validate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource))
+		run(args[0].(context.Context), args[1].(resource.Resource))
 	})
 	return _c
 }

--- a/internal/server/v1/mocks/provider_service.go
+++ b/internal/server/v1/mocks/provider_service.go
@@ -24,11 +24,11 @@ func (_m *ProviderService) EXPECT() *ProviderService_Expecter {
 }
 
 // CreateProvider provides a mock function with given fields: ctx, res
-func (_m *ProviderService) CreateProvider(ctx context.Context, res *provider.Provider) (*provider.Provider, error) {
+func (_m *ProviderService) CreateProvider(ctx context.Context, res provider.Provider) (*provider.Provider, error) {
 	ret := _m.Called(ctx, res)
 
 	var r0 *provider.Provider
-	if rf, ok := ret.Get(0).(func(context.Context, *provider.Provider) *provider.Provider); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, provider.Provider) *provider.Provider); ok {
 		r0 = rf(ctx, res)
 	} else {
 		if ret.Get(0) != nil {
@@ -37,7 +37,7 @@ func (_m *ProviderService) CreateProvider(ctx context.Context, res *provider.Pro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *provider.Provider) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, provider.Provider) error); ok {
 		r1 = rf(ctx, res)
 	} else {
 		r1 = ret.Error(1)
@@ -53,14 +53,14 @@ type ProviderService_CreateProvider_Call struct {
 
 // CreateProvider is a helper method to define mock.On call
 //  - ctx context.Context
-//  - res *provider.Provider
+//  - res provider.Provider
 func (_e *ProviderService_Expecter) CreateProvider(ctx interface{}, res interface{}) *ProviderService_CreateProvider_Call {
 	return &ProviderService_CreateProvider_Call{Call: _e.mock.On("CreateProvider", ctx, res)}
 }
 
-func (_c *ProviderService_CreateProvider_Call) Run(run func(ctx context.Context, res *provider.Provider)) *ProviderService_CreateProvider_Call {
+func (_c *ProviderService_CreateProvider_Call) Run(run func(ctx context.Context, res provider.Provider)) *ProviderService_CreateProvider_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*provider.Provider))
+		run(args[0].(context.Context), args[1].(provider.Provider))
 	})
 	return _c
 }

--- a/internal/server/v1/mocks/resource_service.go
+++ b/internal/server/v1/mocks/resource_service.go
@@ -24,11 +24,11 @@ func (_m *ResourceService) EXPECT() *ResourceService_Expecter {
 }
 
 // CreateResource provides a mock function with given fields: ctx, res
-func (_m *ResourceService) CreateResource(ctx context.Context, res *resource.Resource) (*resource.Resource, error) {
+func (_m *ResourceService) CreateResource(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
 	ret := _m.Called(ctx, res)
 
 	var r0 *resource.Resource
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource) *resource.Resource); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource) *resource.Resource); ok {
 		r0 = rf(ctx, res)
 	} else {
 		if ret.Get(0) != nil {
@@ -37,7 +37,7 @@ func (_m *ResourceService) CreateResource(ctx context.Context, res *resource.Res
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource) error); ok {
 		r1 = rf(ctx, res)
 	} else {
 		r1 = ret.Error(1)
@@ -53,14 +53,14 @@ type ResourceService_CreateResource_Call struct {
 
 // CreateResource is a helper method to define mock.On call
 //  - ctx context.Context
-//  - res *resource.Resource
+//  - res resource.Resource
 func (_e *ResourceService_Expecter) CreateResource(ctx interface{}, res interface{}) *ResourceService_CreateResource_Call {
 	return &ResourceService_CreateResource_Call{Call: _e.mock.On("CreateResource", ctx, res)}
 }
 
-func (_c *ResourceService_CreateResource_Call) Run(run func(ctx context.Context, res *resource.Resource)) *ResourceService_CreateResource_Call {
+func (_c *ResourceService_CreateResource_Call) Run(run func(ctx context.Context, res resource.Resource)) *ResourceService_CreateResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource))
+		run(args[0].(context.Context), args[1].(resource.Resource))
 	})
 	return _c
 }
@@ -204,11 +204,11 @@ func (_c *ResourceService_ListResources_Call) Return(_a0 []*resource.Resource, _
 }
 
 // UpdateResource provides a mock function with given fields: ctx, res
-func (_m *ResourceService) UpdateResource(ctx context.Context, res *resource.Resource) (*resource.Resource, error) {
+func (_m *ResourceService) UpdateResource(ctx context.Context, res resource.Resource) (*resource.Resource, error) {
 	ret := _m.Called(ctx, res)
 
 	var r0 *resource.Resource
-	if rf, ok := ret.Get(0).(func(context.Context, *resource.Resource) *resource.Resource); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Resource) *resource.Resource); ok {
 		r0 = rf(ctx, res)
 	} else {
 		if ret.Get(0) != nil {
@@ -217,7 +217,7 @@ func (_m *ResourceService) UpdateResource(ctx context.Context, res *resource.Res
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *resource.Resource) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Resource) error); ok {
 		r1 = rf(ctx, res)
 	} else {
 		r1 = ret.Error(1)
@@ -233,14 +233,14 @@ type ResourceService_UpdateResource_Call struct {
 
 // UpdateResource is a helper method to define mock.On call
 //  - ctx context.Context
-//  - res *resource.Resource
+//  - res resource.Resource
 func (_e *ResourceService_Expecter) UpdateResource(ctx interface{}, res interface{}) *ResourceService_UpdateResource_Call {
 	return &ResourceService_UpdateResource_Call{Call: _e.mock.On("UpdateResource", ctx, res)}
 }
 
-func (_c *ResourceService_UpdateResource_Call) Run(run func(ctx context.Context, res *resource.Resource)) *ResourceService_UpdateResource_Call {
+func (_c *ResourceService_UpdateResource_Call) Run(run func(ctx context.Context, res resource.Resource)) *ResourceService_UpdateResource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*resource.Resource))
+		run(args[0].(context.Context), args[1].(resource.Resource))
 	})
 	return _c
 }

--- a/internal/server/v1/server.go
+++ b/internal/server/v1/server.go
@@ -37,7 +37,7 @@ type ModuleService interface {
 }
 
 type ProviderService interface {
-	CreateProvider(ctx context.Context, res *provider.Provider) (*provider.Provider, error)
+	CreateProvider(ctx context.Context, res provider.Provider) (*provider.Provider, error)
 	ListProviders(ctx context.Context, parent string, kind string) ([]*provider.Provider, error)
 }
 
@@ -244,7 +244,7 @@ func (server APIServer) CreateProvider(ctx context.Context, request *entropyv1be
 	pro.URN = provider.GenerateURN(*pro)
 	// TODO: add provider validation
 
-	createdProvider, err := server.providerService.CreateProvider(ctx, pro)
+	createdProvider, err := server.providerService.CreateProvider(ctx, *pro)
 	if err != nil {
 		if errors.Is(err, provider.ErrProviderAlreadyExists) {
 			return nil, status.Error(codes.AlreadyExists, "provider already exists")

--- a/internal/server/v1/server.go
+++ b/internal/server/v1/server.go
@@ -24,8 +24,8 @@ var ErrInternal = status.Error(codes.Internal, "internal server error")
 type ResourceService interface {
 	GetResource(ctx context.Context, urn string) (*resource.Resource, error)
 	ListResources(ctx context.Context, parent string, kind string) ([]*resource.Resource, error)
-	CreateResource(ctx context.Context, res *resource.Resource) (*resource.Resource, error)
-	UpdateResource(ctx context.Context, res *resource.Resource) (*resource.Resource, error)
+	CreateResource(ctx context.Context, res resource.Resource) (*resource.Resource, error)
+	UpdateResource(ctx context.Context, res resource.Resource) (*resource.Resource, error)
 	DeleteResource(ctx context.Context, urn string) error
 }
 
@@ -67,7 +67,7 @@ func (server APIServer) CreateResource(ctx context.Context, request *entropyv1be
 		return nil, err
 	}
 
-	createdResource, err := server.resourceService.CreateResource(ctx, res)
+	createdResource, err := server.resourceService.CreateResource(ctx, *res)
 	if err != nil {
 		if errors.Is(err, resource.ErrResourceAlreadyExists) {
 			return nil, status.Error(codes.AlreadyExists, "resource already exists")
@@ -106,7 +106,7 @@ func (server APIServer) UpdateResource(ctx context.Context, request *entropyv1be
 	if err != nil {
 		return nil, err
 	}
-	updatedResource, err := server.resourceService.UpdateResource(ctx, res)
+	updatedResource, err := server.resourceService.UpdateResource(ctx, *res)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (server APIServer) syncResource(ctx context.Context, updatedResource resour
 	if err != nil {
 		return nil, ErrInternal
 	}
-	responseResource, err := server.resourceService.UpdateResource(ctx, syncedResource)
+	responseResource, err := server.resourceService.UpdateResource(ctx, *syncedResource)
 	if err != nil {
 		return nil, ErrInternal
 	}

--- a/internal/server/v1/server_test.go
+++ b/internal/server/v1/server_test.go
@@ -56,7 +56,7 @@ func TestAPIServer_CreateResource(t *testing.T) {
 		}
 
 		resourceService := &mocks.ResourceService{}
-		resourceService.EXPECT().CreateResource(mock.Anything, mock.Anything).Run(func(ctx context.Context, res *resource.Resource) {
+		resourceService.EXPECT().CreateResource(mock.Anything, mock.Anything).Run(func(ctx context.Context, res resource.Resource) {
 			assert.Equal(t, "p-testdata-gl-testname-log", res.URN)
 		}).Return(&resource.Resource{
 			URN:    "p-testdata-gl-testname-log",
@@ -72,7 +72,7 @@ func TestAPIServer_CreateResource(t *testing.T) {
 			UpdatedAt: createdAt,
 		}, nil).Once()
 
-		resourceService.EXPECT().UpdateResource(mock.Anything, mock.Anything).Run(func(ctx context.Context, res *resource.Resource) {
+		resourceService.EXPECT().UpdateResource(mock.Anything, mock.Anything).Run(func(ctx context.Context, res resource.Resource) {
 			assert.Equal(t, "p-testdata-gl-testname-log", res.URN)
 			assert.Equal(t, resource.StatusCompleted, res.Status)
 		}).Return(&resource.Resource{
@@ -307,7 +307,7 @@ func TestAPIServer_UpdateResource(t *testing.T) {
 
 		resourceService.EXPECT().
 			UpdateResource(mock.Anything, mock.Anything).
-			Run(func(ctx context.Context, res *resource.Resource) {
+			Run(func(ctx context.Context, res resource.Resource) {
 				assert.Equal(t, resource.StatusPending, res.Status)
 			}).
 			Return(&resource.Resource{
@@ -326,7 +326,7 @@ func TestAPIServer_UpdateResource(t *testing.T) {
 
 		resourceService.EXPECT().
 			UpdateResource(mock.Anything, mock.Anything).
-			Run(func(ctx context.Context, res *resource.Resource) {
+			Run(func(ctx context.Context, res resource.Resource) {
 				assert.Equal(t, resource.StatusCompleted, res.Status)
 			}).
 			Return(&resource.Resource{

--- a/internal/server/v1/server_test.go
+++ b/internal/server/v1/server_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestAPIServer_CreateResource(t *testing.T) {
 	t.Parallel()
-	
+
 	t.Run("test create new resource", func(t *testing.T) {
 		createdAt := time.Now()
 		updatedAt := createdAt.Add(time.Minute)
@@ -674,7 +674,7 @@ func TestAPIServer_ApplyAction(t *testing.T) {
 	t.Run("test applying action successfully", func(t *testing.T) {
 		createdAt := time.Now()
 		updatedAt := createdAt.Add(time.Minute)
-		r := &resource.Resource{
+		r := resource.Resource{
 			URN:    "p-testdata-gl-testname-log",
 			Name:   "testname",
 			Parent: "p-testdata-gl",
@@ -687,7 +687,7 @@ func TestAPIServer_ApplyAction(t *testing.T) {
 			CreatedAt: createdAt,
 			UpdatedAt: updatedAt,
 		}
-		rDash := &resource.Resource{
+		rDash := resource.Resource{
 			URN:    "p-testdata-gl-testname-log",
 			Name:   "testname",
 			Parent: "p-testdata-gl",
@@ -700,7 +700,7 @@ func TestAPIServer_ApplyAction(t *testing.T) {
 			CreatedAt: createdAt,
 			UpdatedAt: updatedAt,
 		}
-		rProto, _ := resourceToProto(r)
+		rProto, _ := resourceToProto(&r)
 		want := &entropyv1beta1.ApplyActionResponse{
 			Resource: rProto,
 		}
@@ -713,17 +713,17 @@ func TestAPIServer_ApplyAction(t *testing.T) {
 		resourceService := &mocks.ResourceService{}
 		resourceService.EXPECT().
 			GetResource(mock.Anything, "p-testdata-gl-testname-log").
-			Return(rDash, nil).Once()
+			Return(&rDash, nil).Once()
 
 		resourceService.EXPECT().
 			UpdateResource(mock.Anything, mock.Anything).
-			Return(r, error(nil)).Once()
+			Return(&r, error(nil)).Once()
 
 		moduleService := &mocks.ModuleService{}
 		moduleService.EXPECT().Act(mock.Anything, rDash, "escalate", map[string]interface{}{}).Return(map[string]interface{}{
 			"log_level": "WARN",
 		}, nil).Once()
-		moduleService.EXPECT().Sync(mock.Anything, mock.Anything).Run(func(_ context.Context, r *resource.Resource) {
+		moduleService.EXPECT().Sync(mock.Anything, mock.Anything).Run(func(_ context.Context, r resource.Resource) {
 			assert.Equal(t, "WARN", r.Configs["log_level"])
 		}).Return(&resource.Resource{
 			URN:    "p-testdata-gl-testname-log",

--- a/internal/store/mongodb/provider_repository.go
+++ b/internal/store/mongodb/provider_repository.go
@@ -24,12 +24,12 @@ func (rc *ProviderRepository) Migrate() error {
 	return createUniqueIndex(rc.collection, "urn", 1)
 }
 
-func (rc *ProviderRepository) Create(Provider *provider.Provider) error {
-	Provider.URN = provider.GenerateURN(*Provider)
-	Provider.CreatedAt = time.Now()
-	Provider.UpdatedAt = time.Now()
+func (rc *ProviderRepository) Create(pro provider.Provider) error {
+	pro.URN = provider.GenerateURN(pro)
+	pro.CreatedAt = time.Now()
+	pro.UpdatedAt = time.Now()
 
-	_, err := rc.collection.InsertOne(context.TODO(), Provider)
+	_, err := rc.collection.InsertOne(context.TODO(), pro)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return fmt.Errorf("%w: %s", provider.ErrProviderAlreadyExists, err)

--- a/internal/store/mongodb/resource_repository.go
+++ b/internal/store/mongodb/resource_repository.go
@@ -37,7 +37,7 @@ func createUniqueIndex(collection *mongo.Collection, key string, order int) erro
 	return err
 }
 
-func (rc *ResourceRepository) Create(res *resource.Resource) error {
+func (rc *ResourceRepository) Create(res resource.Resource) error {
 	res.CreatedAt = time.Now()
 	res.UpdatedAt = time.Now()
 
@@ -51,7 +51,7 @@ func (rc *ResourceRepository) Create(res *resource.Resource) error {
 	return nil
 }
 
-func (rc *ResourceRepository) Update(r *resource.Resource) error {
+func (rc *ResourceRepository) Update(r resource.Resource) error {
 	r.UpdatedAt = time.Now()
 	singleResult := rc.collection.FindOneAndUpdate(context.TODO(),
 		map[string]interface{}{"urn": r.URN},

--- a/internal/store/mongodb/resource_repository_test.go
+++ b/internal/store/mongodb/resource_repository_test.go
@@ -42,7 +42,7 @@ func TestResourceRepository_Create(t *testing.T) {
 		collection *mongo.Collection
 	}
 	type args struct {
-		resource *resource.Resource
+		resource resource.Resource
 	}
 	tests := []struct {
 		name    string
@@ -56,7 +56,7 @@ func TestResourceRepository_Create(t *testing.T) {
 			setup:  func(mt *mtest.T) { mt.AddMockResponses(mtest.CreateSuccessResponse()) },
 			fields: func(mt *mtest.T) fields { return fields{mt.Coll} },
 			args: func(mt *mtest.T) args {
-				return args{&resource.Resource{
+				return args{resource.Resource{
 					URN:       "p-testdata-gl-testname-log",
 					Name:      "testname",
 					Parent:    "p-testdata-gl",
@@ -83,7 +83,7 @@ func TestResourceRepository_Create(t *testing.T) {
 				return fields{mt.Coll}
 			},
 			args: func(mt *mtest.T) args {
-				return args{&resource.Resource{
+				return args{resource.Resource{
 					URN:       "p-testdata-gl-testname-log",
 					Name:      "testname",
 					Parent:    "p-testdata-gl",

--- a/plugins/modules/firehose/module.go
+++ b/plugins/modules/firehose/module.go
@@ -316,7 +316,7 @@ func New(providerRepository provider.Repository) *Module {
 	}
 }
 
-func (m *Module) Apply(r *resource.Resource) (resource.Status, error) {
+func (m *Module) Apply(r resource.Resource) (resource.Status, error) {
 	for _, p := range r.Providers {
 		p, err := m.providerRepository.GetByURN(p.URN)
 		if err != nil {
@@ -348,7 +348,7 @@ func (m *Module) Apply(r *resource.Resource) (resource.Status, error) {
 	return resource.StatusCompleted, nil
 }
 
-func (m *Module) Validate(r *resource.Resource) error {
+func (m *Module) Validate(r resource.Resource) error {
 	resourceLoader := gjs.NewGoLoader(r.Configs)
 	result, err := m.schema.Validate(resourceLoader)
 	if err != nil {
@@ -365,7 +365,7 @@ func (m *Module) Validate(r *resource.Resource) error {
 	return nil
 }
 
-func (m *Module) Act(r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (m *Module) Act(r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	releaseConfig, err := getReleaseConfig(r)
 	if err != nil {
 		return nil, err
@@ -383,7 +383,7 @@ func (m *Module) Act(r *resource.Resource, action string, params map[string]inte
 	return r.Configs, nil
 }
 
-func getReleaseConfig(r *resource.Resource) (*helm.ReleaseConfig, error) {
+func getReleaseConfig(r resource.Resource) (*helm.ReleaseConfig, error) {
 	releaseConfig := helm.DefaultReleaseConfig()
 	releaseConfig.Repository = defaultRepositoryString
 	releaseConfig.Chart = defaultChartString

--- a/plugins/modules/log/module.go
+++ b/plugins/modules/log/module.go
@@ -72,7 +72,7 @@ func New(logger *zap.Logger) *Module {
 	}
 }
 
-func (m *Module) Apply(r *resource.Resource) (resource.Status, error) {
+func (m *Module) Apply(r resource.Resource) (resource.Status, error) {
 	var cfg config
 	if err := mapstructure.Decode(r.Configs, &cfg); err != nil {
 		return resource.StatusError, errors.New("unable to parse configs")
@@ -93,7 +93,7 @@ func (m *Module) Apply(r *resource.Resource) (resource.Status, error) {
 	return resource.StatusCompleted, nil
 }
 
-func (m *Module) Validate(r *resource.Resource) error {
+func (m *Module) Validate(r resource.Resource) error {
 	resourceLoader := gjs.NewGoLoader(r.Configs)
 	result, err := m.schema.Validate(resourceLoader)
 	if err != nil {
@@ -110,7 +110,7 @@ func (m *Module) Validate(r *resource.Resource) error {
 	return nil
 }
 
-func (m *Module) Act(r *resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
+func (m *Module) Act(r resource.Resource, action string, params map[string]interface{}) (map[string]interface{}, error) {
 	switch action {
 	case "escalate":
 		r.Configs[levelConfigString] = increaseLogLevel(r.Configs[levelConfigString].(Level))
@@ -118,7 +118,7 @@ func (m *Module) Act(r *resource.Resource, action string, params map[string]inte
 	return r.Configs, nil
 }
 
-func (m *Module) Log(ctx context.Context, r *resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
+func (m *Module) Log(ctx context.Context, r resource.Resource, filter map[string]string) (<-chan module.LogChunk, error) {
 	var cfg config
 	if err := mapstructure.Decode(r.Configs, &cfg); err != nil {
 		return nil, errors.New("unable to parse configs")


### PR DESCRIPTION
Many core interfaces are using pointer types in arguments which is error-prone since mutations in the called function can end-up accidentally propagating back to the caller site introducing critical bugs.

This PR refactors interfaces and their usages to get rid of such pointer type arguments.