### PR TITLE
fix(config): handle config file not found error and print log for the same

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/odpf/entropy/internal/server"
+	"github.com/odpf/entropy/pkg/errors"
 	"github.com/odpf/entropy/pkg/logger"
 	"github.com/odpf/entropy/pkg/metric"
 )
@@ -63,8 +65,11 @@ func loadConfig(cmd *cobra.Command) (Config, error) {
 
 	var cfg Config
 	err := config.NewLoader(opts...).Load(&cfg)
-	if err != nil {
+	if errors.As(err, &config.ConfigFileNotFoundError{}) {
+		log.Println(err)
+	} else {
 		return cfg, err
 	}
+
 	return cfg, nil
 }


### PR DESCRIPTION
Fixes #60 