### PR TITLE
refactor: change urn format as per OIP-001-unified-urn

### DIFF
--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -119,6 +119,6 @@ func (f Filter) isMatch(r Resource) bool {
 }
 
 func generateURN(res Resource) string {
-	parts := []string{"urn", "odpf", "entropy", res.Kind, res.Project, res.Name}
+	parts := []string{"orn", "entropy", res.Kind, res.Project, res.Name}
 	return strings.Join(parts, urnSeparator)
 }

--- a/core/write_test.go
+++ b/core/write_test.go
@@ -133,7 +133,7 @@ func TestService_CreateResource(t *testing.T) {
 					Enqueue(mock.Anything, mock.Anything).
 					Run(func(ctx context.Context, jobs ...worker.Job) {
 						assert.Len(t, jobs, 1)
-						assert.Equal(t, "sync-urn:odpf:entropy:mock:project:child-1650536955", jobs[0].ID)
+						assert.Equal(t, "sync-orn:entropy:mock:project:child-1650536955", jobs[0].ID)
 					}).
 					Return(nil)
 
@@ -145,7 +145,7 @@ func TestService_CreateResource(t *testing.T) {
 				Project: "project",
 			},
 			want: &resource.Resource{
-				URN:       "urn:odpf:entropy:mock:project:child",
+				URN:       "orn:entropy:mock:project:child",
 				Kind:      "mock",
 				Name:      "child",
 				Project:   "project",
@@ -179,7 +179,7 @@ func TestService_UpdateResource(t *testing.T) {
 	t.Parallel()
 	testErr := errors.New("failed")
 	testResource := resource.Resource{
-		URN:       "urn:odpf:entropy:mock:project:child",
+		URN:       "orn:entropy:mock:project:child",
 		Kind:      "mock",
 		Name:      "child",
 		Project:   "project",
@@ -201,13 +201,13 @@ func TestService_UpdateResource(t *testing.T) {
 				t.Helper()
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:project:child").
+					GetByURN(mock.Anything, "orn:entropy:mock:project:child").
 					Return(nil, errors.ErrNotFound).
 					Once()
 
 				return core.New(resourceRepo, nil, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:project:child",
+			urn:     "orn:entropy:mock:project:child",
 			newSpec: resource.Spec{Configs: []byte(`{"foo": "bar"}`)},
 			want:    nil,
 			wantErr: errors.ErrNotFound,
@@ -223,13 +223,13 @@ func TestService_UpdateResource(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:project:child").
+					GetByURN(mock.Anything, "orn:entropy:mock:project:child").
 					Return(&testResource, nil).
 					Once()
 
 				return core.New(resourceRepo, mod, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:project:child",
+			urn:     "orn:entropy:mock:project:child",
 			newSpec: resource.Spec{Configs: []byte(`{"foo": "bar"}`)},
 			want:    nil,
 			wantErr: errors.ErrInvalid,
@@ -245,7 +245,7 @@ func TestService_UpdateResource(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:project:child").
+					GetByURN(mock.Anything, "orn:entropy:mock:project:child").
 					Return(&testResource, nil).
 					Once()
 
@@ -262,7 +262,7 @@ func TestService_UpdateResource(t *testing.T) {
 					Enqueue(mock.Anything, mock.Anything).
 					Run(func(ctx context.Context, jobs ...worker.Job) {
 						assert.Len(t, jobs, 1)
-						assert.Equal(t, jobs[0].ID, "sync-urn:odpf:entropy:mock:project:child-1650536955")
+						assert.Equal(t, jobs[0].ID, "sync-orn:entropy:mock:project:child-1650536955")
 						assert.Equal(t, jobs[0].Kind, "sync_resource")
 					}).
 					Return(nil).
@@ -270,7 +270,7 @@ func TestService_UpdateResource(t *testing.T) {
 
 				return core.New(resourceRepo, mod, mockWorker, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:project:child",
+			urn:     "orn:entropy:mock:project:child",
 			newSpec: resource.Spec{Configs: []byte(`{"foo": "bar"}`)},
 			want:    nil,
 			wantErr: testErr,
@@ -283,7 +283,7 @@ func TestService_UpdateResource(t *testing.T) {
 				mod.EXPECT().
 					Plan(mock.Anything, mock.Anything, mock.Anything).
 					Return(&resource.Resource{
-						URN:     "urn:odpf:entropy:mock:project:child",
+						URN:     "orn:entropy:mock:project:child",
 						Kind:    "mock",
 						Name:    "child",
 						Project: "project",
@@ -296,7 +296,7 @@ func TestService_UpdateResource(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:project:child").
+					GetByURN(mock.Anything, "orn:entropy:mock:project:child").
 					Return(&testResource, nil).Once()
 
 				resourceRepo.EXPECT().
@@ -314,17 +314,17 @@ func TestService_UpdateResource(t *testing.T) {
 					Return(nil).
 					Run(func(ctx context.Context, jobs ...worker.Job) {
 						assert.Len(t, jobs, 1)
-						assert.Equal(t, jobs[0].ID, "sync-urn:odpf:entropy:mock:project:child-1650536955")
+						assert.Equal(t, jobs[0].ID, "sync-orn:entropy:mock:project:child-1650536955")
 						assert.Equal(t, jobs[0].Kind, "sync_resource")
 					}).
 					Once()
 
 				return core.New(resourceRepo, mod, mockWorker, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:project:child",
+			urn:     "orn:entropy:mock:project:child",
 			newSpec: resource.Spec{Configs: []byte(`{"foo": "bar"}`)},
 			want: &resource.Resource{
-				URN:       "urn:odpf:entropy:mock:project:child",
+				URN:       "orn:entropy:mock:project:child",
 				Kind:      "mock",
 				Name:      "child",
 				Project:   "project",
@@ -374,13 +374,13 @@ func TestService_DeleteResource(t *testing.T) {
 				t.Helper()
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(nil, testErr).
 					Once()
 
 				return core.New(resourceRepo, nil, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: testErr,
 		},
 		{
@@ -391,7 +391,7 @@ func TestService_DeleteResource(t *testing.T) {
 				mod.EXPECT().
 					Plan(mock.Anything, mock.Anything, mock.Anything).
 					Return(&resource.Resource{
-						URN:       "urn:odpf:entropy:mock:project:child",
+						URN:       "orn:entropy:mock:project:child",
 						Kind:      "mock",
 						Name:      "child",
 						Project:   "project",
@@ -402,9 +402,9 @@ func TestService_DeleteResource(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(&resource.Resource{
-						URN:       "urn:odpf:entropy:mock:project:child",
+						URN:       "orn:entropy:mock:project:child",
 						Kind:      "mock",
 						Name:      "child",
 						Project:   "project",
@@ -421,7 +421,7 @@ func TestService_DeleteResource(t *testing.T) {
 
 				return core.New(resourceRepo, mod, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: errors.ErrInternal,
 		},
 		{
@@ -432,7 +432,7 @@ func TestService_DeleteResource(t *testing.T) {
 				mod.EXPECT().
 					Plan(mock.Anything, mock.Anything, mock.Anything).
 					Return(&resource.Resource{
-						URN:       "urn:odpf:entropy:mock:project:child",
+						URN:       "orn:entropy:mock:project:child",
 						Kind:      "mock",
 						Name:      "child",
 						Project:   "project",
@@ -443,9 +443,9 @@ func TestService_DeleteResource(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(&resource.Resource{
-						URN:       "urn:odpf:entropy:mock:project:child",
+						URN:       "orn:entropy:mock:project:child",
 						Kind:      "mock",
 						Name:      "child",
 						Project:   "project",
@@ -462,7 +462,7 @@ func TestService_DeleteResource(t *testing.T) {
 
 				return core.New(resourceRepo, mod, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			wantErr: nil,
 		},
 	}
@@ -506,13 +506,13 @@ func TestService_ApplyAction(t *testing.T) {
 				t.Helper()
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(nil, errors.ErrNotFound).
 					Once()
 
 				return core.New(resourceRepo, nil, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
 			want:    nil,
 			wantErr: errors.ErrNotFound,
@@ -523,9 +523,9 @@ func TestService_ApplyAction(t *testing.T) {
 				t.Helper()
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(&resource.Resource{
-						URN:     "urn:odpf:entropy:mock:foo:bar",
+						URN:     "orn:entropy:mock:foo:bar",
 						Kind:    "mock",
 						Project: "foo",
 						Name:    "bar",
@@ -534,7 +534,7 @@ func TestService_ApplyAction(t *testing.T) {
 
 				return core.New(resourceRepo, nil, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
 			want:    nil,
 			wantErr: errors.ErrInvalid,
@@ -551,9 +551,9 @@ func TestService_ApplyAction(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(&resource.Resource{
-						URN:     "urn:odpf:entropy:mock:foo:bar",
+						URN:     "orn:entropy:mock:foo:bar",
 						Kind:    "mock",
 						Project: "foo",
 						Name:    "bar",
@@ -563,7 +563,7 @@ func TestService_ApplyAction(t *testing.T) {
 
 				return core.New(resourceRepo, mod, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:     "urn:odpf:entropy:mock:foo:bar",
+			urn:     "orn:entropy:mock:foo:bar",
 			action:  sampleAction,
 			want:    nil,
 			wantErr: errors.ErrInternal,
@@ -576,7 +576,7 @@ func TestService_ApplyAction(t *testing.T) {
 				mod.EXPECT().
 					Plan(mock.Anything, mock.Anything, sampleAction).
 					Return(&resource.Resource{
-						URN:     "urn:odpf:entropy:mock:foo:bar",
+						URN:     "orn:entropy:mock:foo:bar",
 						Kind:    "mock",
 						Project: "foo",
 						Name:    "bar",
@@ -586,9 +586,9 @@ func TestService_ApplyAction(t *testing.T) {
 
 				resourceRepo := &mocks.ResourceStore{}
 				resourceRepo.EXPECT().
-					GetByURN(mock.Anything, "urn:odpf:entropy:mock:foo:bar").
+					GetByURN(mock.Anything, "orn:entropy:mock:foo:bar").
 					Return(&resource.Resource{
-						URN:       "urn:odpf:entropy:mock:foo:bar",
+						URN:       "orn:entropy:mock:foo:bar",
 						Kind:      "mock",
 						Project:   "foo",
 						Name:      "bar",
@@ -603,10 +603,10 @@ func TestService_ApplyAction(t *testing.T) {
 
 				return core.New(resourceRepo, mod, &mocks.AsyncWorker{}, deadClock, nil)
 			},
-			urn:    "urn:odpf:entropy:mock:foo:bar",
+			urn:    "orn:entropy:mock:foo:bar",
 			action: sampleAction,
 			want: &resource.Resource{
-				URN:       "urn:odpf:entropy:mock:foo:bar",
+				URN:       "orn:entropy:mock:foo:bar",
 				Kind:      "mock",
 				Project:   "foo",
 				Name:      "bar",

--- a/docs/concepts/resource-life-cycle.md
+++ b/docs/concepts/resource-life-cycle.md
@@ -49,7 +49,7 @@ For instance, a [firehose](https://github.com/odpf/firehose) resource looks like
                 "log_level": "INFO"
             },
             "dependencies": {
-                "deployment_cluster": "urn:odpf:entropy:kubernetes:godata"
+                "deployment_cluster": "orn:entropy:kubernetes:godata"
             }
     },
     "state": {
@@ -75,7 +75,7 @@ POST /api/v1beta1/resources
         "log_level": "INFO"
     },
     "dependencies": {
-        "deployment_cluster": "urn:odpf:entropy:kubernetes:godata"
+        "deployment_cluster": "orn:entropy:kubernetes:godata"
     }
 }
 ```
@@ -88,7 +88,7 @@ Here is the resource returned
 
 ```
 {
-    "urn": "urn:odpf:entropy:firehose:bar:foo",
+    "urn": "orn:entropy:firehose:bar:foo",
     "created_at": "2022-04-28T11:00:00.000Z",
     "updated_at": "2022-04-28T11:00:00.000Z",
     "name": "foo",
@@ -98,7 +98,7 @@ Here is the resource returned
         "log_level": "INFO"
     },
     "dependencies": {
-        "deployment_cluster": "urn:odpf:entropy:kubernetes:godata"
+        "deployment_cluster": "orn:entropy:kubernetes:godata"
     },
     "state": {
         "status": "STATUS_PENDING",
@@ -120,7 +120,7 @@ A job-queue model is used to handle sync operations. Every mutation (create/upda
 
 ```
 {
-    "urn": "urn:odpf:entropy:firehose:bar:foo",
+    "urn": "orn:entropy:firehose:bar:foo",
     "kind": "firehose",
     "name": "foo",
     "project": "bar",
@@ -130,7 +130,7 @@ A job-queue model is used to handle sync operations. Every mutation (create/upda
         "log_level": "INFO"
     },
     "dependencies": {
-        "deployment_cluster": "urn:odpf:entropy:kubernetes:godata"
+        "deployment_cluster": "orn:entropy:kubernetes:godata"
     },
     "state": {
         "status": "COMPLETED",
@@ -144,7 +144,7 @@ A job-queue model is used to handle sync operations. Every mutation (create/upda
 ### 5. Execute Action
 
 ```
-POST /api/v1beta1/resources/urn:odpf:entropy:firehose:bar:foo/execute
+POST /api/v1beta1/resources/orn:entropy:firehose:bar:foo/execute
 
 {
     "action": "increase_log_level"
@@ -155,7 +155,7 @@ This will trigger Plan again, and leave the resource in `STATUS_PENDING` state. 
 
 ```
 {
-    "urn": "urn:odpf:entropy:firehose:bar:foo",
+    "urn": "orn:entropy:firehose:bar:foo",
     "kind": "firehose",
     "name": "foo",
     "project": "bar",
@@ -165,7 +165,7 @@ This will trigger Plan again, and leave the resource in `STATUS_PENDING` state. 
         "log_level": "WARN"
     },
     "dependencies": {
-        "deployment_cluster": "urn:odpf:entropy:kubernetes:godata"
+        "deployment_cluster": "orn:entropy:kubernetes:godata"
     },
     "state": {
         "status": "PENDING",

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -66,7 +66,7 @@ curl --location --request POST '{{HOST}}/api/v1beta1/resources' \
 		"dependencies": [
 			{
 				"key": "kube_cluster",
-				"value": "urn:odpf:entropy:kubernetes:test:p-godata-pilot"
+				"value": "orn:entropy:kubernetes:test:p-godata-pilot"
 			}
 		],
 		"configs": {

--- a/modules/firehose/plan_test.go
+++ b/modules/firehose/plan_test.go
@@ -16,7 +16,7 @@ func TestFirehoseModule_Plan(t *testing.T) {
 	t.Parallel()
 
 	res := resource.Resource{
-		URN:     "urn:odpf:entropy:firehose:test",
+		URN:     "orn:entropy:firehose:test",
 		Kind:    "firehose",
 		Name:    "test",
 		Project: "demo",
@@ -50,7 +50,7 @@ func TestFirehoseModule_Plan(t *testing.T) {
 				Params: []byte(`{"state":"RUNNING","firehose":{"replicas":1,"kafka_broker_address":"localhost:9092","kafka_topic":"test-topic","kafka_consumer_id":"test-consumer-id","env_variables":{}}}`),
 			},
 			want: &resource.Resource{
-				URN:     "urn:odpf:entropy:firehose:test",
+				URN:     "orn:entropy:firehose:test",
 				Kind:    "firehose",
 				Name:    "test",
 				Project: "demo",
@@ -80,7 +80,7 @@ func TestFirehoseModule_Plan(t *testing.T) {
 				Params: []byte(`{"replicas": 5}`),
 			},
 			want: &resource.Resource{
-				URN:     "urn:odpf:entropy:firehose:test",
+				URN:     "orn:entropy:firehose:test",
 				Kind:    "firehose",
 				Name:    "test",
 				Project: "demo",
@@ -101,7 +101,7 @@ func TestFirehoseModule_Plan(t *testing.T) {
 				Params: []byte(`{"to":"DATETIME","datetime":"2022-06-22T00:00:00+00:00"}`),
 			},
 			want: &resource.Resource{
-				URN:     "urn:odpf:entropy:firehose:test",
+				URN:     "orn:entropy:firehose:test",
 				Kind:    "firehose",
 				Name:    "test",
 				Project: "demo",


### PR DESCRIPTION
⚠️ Existing URNs should continue to work fine within Entropy. But this is a breaking change on the format of the URN. ⚠️