### PR TITLE
fix: json schema for kube config

### DIFF
--- a/modules/firehose/config.go
+++ b/modules/firehose/config.go
@@ -50,11 +50,7 @@ func (mc *moduleConfig) validateAndSanitize(r resource.Resource) error {
 	return nil
 }
 
-func generateFirehoseName(r resource.Resource) string {
-	return fmt.Sprintf("%s-%s-firehose", r.Project, r.Name)
-}
-
-func (mc moduleConfig) GetHelmReleaseConfig(r resource.Resource) (*helm.ReleaseConfig, error) {
+func (mc *moduleConfig) GetHelmReleaseConfig(r resource.Resource) (*helm.ReleaseConfig, error) {
 	var output Output
 	err := json.Unmarshal(r.State.Output, &output)
 	if err != nil {
@@ -94,10 +90,14 @@ func (mc moduleConfig) GetHelmReleaseConfig(r resource.Resource) (*helm.ReleaseC
 	return rc, nil
 }
 
-func (mc moduleConfig) JSON() []byte {
+func (mc *moduleConfig) JSON() []byte {
 	b, err := json.Marshal(mc)
 	if err != nil {
 		panic(err)
 	}
 	return b
+}
+
+func generateFirehoseName(r resource.Resource) string {
+	return fmt.Sprintf("%s-%s-firehose", r.Project, r.Name)
 }

--- a/modules/kubernetes/config_schema.json
+++ b/modules/kubernetes/config_schema.json
@@ -1,12 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "host": {
       "type": "string",
-      "format": "uri",
-      "pattern": "^https?://"
+      "format": "uri"
     },
     "insecure": {
       "type": "boolean",
@@ -21,61 +19,38 @@
     "client_certificate": {
       "type": "string"
     },
-    "cluster_ca_certificate": {
+    "client_ca_certificate": {
       "type": "string"
-    },
-    "timeout": {
-      "type": "number",
-      "default": 100000000
     }
   },
-  "allOf": [
+  "required": [
+    "host"
+  ],
+  "anyOf": [
     {
-      "oneOf": [
-        {
-          "required": [
-            "token"
-          ]
-        },
-        {
-          "allOf": [
-            {
-              "required": [
-                "client_key"
-              ]
-            },
-            {
-              "required": [
-                "client_certificate"
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "oneOf": [
-        {
-          "required": [
-            "cluster_ca_certificate"
-          ]
-        },
-        {
-          "properties": {
-            "insecure": {
-              "const": true
-            }
-          },
-          "required": [
-            "insecure"
-          ]
-        }
+      "required": [
+        "token"
       ]
     },
     {
       "required": [
-        "host"
-      ]
+        "client_key",
+        "client_certificate"
+      ],
+      "if": {
+        "not": {
+          "properties": {
+            "insecure": {
+              "const": true
+            }
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "client_ca_certificate"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixed the kube config validation schema to enforce:

1. `host` must be present and should be a valid URI
2. `insecure`  optional (defaults to false)
3. either `token` OR `client_key, client_certificate` pair must be present.
4. If `insecure=false` and token is not used, then `client_ca_certificate` must be present.